### PR TITLE
fix: add example config and pipeline for sonar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2017, Screwdriver
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Pipeline to deploy sonarqube server to kubernetes. Currently it only supports updating sonarqube's image. Other configuration requires manual update via helm.
 
 ## First Time Deployment
-To simplify the deployment, we are using helm, the package manager for k8s, to bundle all we need for sonar and deploy them all in once. Example `values.yaml` can be found under `config-example` folder. The actual config files are stored somewhere else secretly.
+To simplify the deployment, we are using helm, the package manager for k8s, to bundle all we need for sonar and deploy them all at once. Example `values.yaml` can be found under `config-example` folder. The actual config files are stored somewhere else secretly.
 - Prerequisite:
     1. install helm client on your dev machine: `brew install kubernetes-helm`
     2. init helm in k8s cluster: https://docs.helm.sh/using_helm
@@ -57,7 +57,7 @@ To simplify the deployment, we are using helm, the package manager for k8s, to b
 - Manual update in sonar UI:
 
     For the following config, it's not configurable during boot time. Need to do it after sonar is up and running.
-  1. Go to **${your-sonar-host}** and log in as `admin` with default password `admin`.
+  1. Go to **${your-sonar-host}** and log in as `admin`.
   2. Go to **${your-sonar-host}/account/security**: change the default admin password
   3. Go to **${your-sonar-host}/admin/permissions**: unselect `Execute Analysis` and `Create Projects` for group `Anyone`
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
 # sonar-pipeline
-Pipeline to deploy sonarqube server to kubernetes
+Pipeline to deploy sonarqube server to kubernetes. Currently it only supports updating sonarqube's image. Other configuration requires manual update via helm.
+
+## First Time Deployment
+To simplify the deployment, we are using helm, the package manager for k8s, to bundle all we need for sonar and deploy them all in once. Example `values.yaml` can be found under `config-example` folder. The actual config files are stored somewhere else secretly.
+- Prerequisite:
+    1. install helm client on your dev machine: `brew install kubernetes-helm`
+    2. init helm in k8s cluster: https://docs.helm.sh/using_helm
+- Deployment:
+    1. Switch to the desired context
+    ```bash
+    kubectl config use-context desired-cluster-context
+    ```
+
+    2. Deploy beta sonar using sonarqube chart
+    ```bash
+    helm install --name beta -f beta-values.yaml stable/sonarqube
+    ```
+
+    3. Deploy prod sonar using sonarqube chart
+    ```bash
+    helm install --name prod -f values.yaml stable/sonarqube
+    ```
+
+    After deployment, you should be able to see such a set of resources created for sonarqube, e.g. for beta:
+
+    ```bash
+    ==> v1/Service
+    beta-postgresql  
+    beta-sonarqube   
+
+    ==> v1beta1/Deployment
+    beta-postgresql  
+    beta-sonarqube   
+
+    ==> v1beta1/Ingress
+    beta-sonarqube
+
+    ==> v1/Pod(related)
+    beta-postgresql
+    beta-sonarqube
+
+    ==> v1/Secret
+    beta-postgresql
+
+    ==> v1/ConfigMap
+    beta-sonarqube-config         
+    beta-sonarqube-install-plugins  
+    beta-sonarqube-startup          
+    beta-sonarqube-tests            
+
+    ==> v1/PersistentVolumeClaim
+    beta-postgresql   
+    beta-sonarqube
+    ```
+
+- Manual update in sonar UI:
+
+    For the following config, it's not configurable during boot time. Need to do it after sonar is up and running.
+  1. Go to **${your-sonar-host}** and log in as `admin` with default password `admin`.
+  2. Go to **${your-sonar-host}/account/security**: change the default admin password
+  3. Go to **${your-sonar-host}/admin/permissions**: unselect `Execute Analysis` and `Create Projects` for group `Anyone`
+
+  **Notes**: all these configurations will be persistent as long as the PVC(persistent volume claim) is not deleted.
+
+## Update config
+```bash
+helm upgrade -f beta-values.yaml beta stable/sonarqube
+helm upgrade -f values.yaml prod stable/sonarqube
+```
+
+## List helm releases
+```bash
+helm list
+```
+
+## Delete the whole sonar system
+Be careful about running this command, it will wipe out everything for sonar even the PVC.
+```bash
+helm del --purge beta
+helm del --purge beta
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # sonar-pipeline
+ [![Build Status][status-image]][status-url] [![Open Issues][issues-image]][issues-url]![License][license-image] [![Slack][slack-image]][slack-url]
+
 Pipeline to deploy sonarqube server to kubernetes. Currently it only supports updating sonarqube's image. Other configuration requires manual update via helm.
 
 ## First Time Deployment
@@ -80,3 +82,17 @@ Be careful about running this command, it will wipe out everything for sonar eve
 helm del --purge beta
 helm del --purge beta
 ```
+
+## License
+
+Code licensed under the BSD 3-Clause license. See LICENSE file for terms.
+
+[license-image]: https://img.shields.io/npm/l/screwdriver-api.svg
+[issues-image]: https://img.shields.io/github/issues/screwdriver-cd/screwdriver.svg
+[issues-url]: https://github.com/screwdriver-cd/screwdriver/issues
+[status-image]: https://cd.screwdriver.cd/pipelines/704/badge
+[status-url]: https://cd.screwdriver.cd/pipelines/704
+[daviddm-image]: https://david-dm.org/screwdriver-cd/screwdriver.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/screwdriver-cd/screwdriver
+[slack-image]: http://slack.screwdriver.cd/badge.svg
+[slack-url]: http://slack.screwdriver.cd/

--- a/config-example/values.yaml
+++ b/config-example/values.yaml
@@ -1,0 +1,114 @@
+# Default values for sonarqube.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+replicaCount: 1
+image:
+  repository: sonarqube
+  tag: 6.7.3
+service:
+  name: sonarqube
+  type: LoadBalancer
+  externalPort: 80
+  internalPort: 9000
+  annotations:
+  # May be used in example for internal load balancing in GCP:
+  # cloud.google.com/load-balancer-type: Internal
+ingress:
+  enabled: true
+  # Used to create an Ingress record.
+  hosts:
+    - sonar.screwdriver.cd
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  tls:
+  # Secrets must be manually created in the namespace.
+  - secretName: sonar-tls
+    hosts:
+      - sonar.screwdriver.cd
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+affinity: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+readinessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+  failureThreshold: 6
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 30
+
+# Set extra env variables. Like proxy settings.
+extraEnv: {}
+
+resources:
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 500m
+    # memory need to be above 2Gi to start the server
+    memory: 3Gi
+# requests:
+#  cpu: 100m
+#  memory: 128Mi
+persistence:
+  enabled: true
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 10Gi
+
+# List of plugins to install.
+# For example:
+# plugins:
+#  install:
+#    - "https://github.com/AmadeusITGroup/sonar-stash/releases/download/1.3.0/sonar-stash-plugin-1.3.0.jar"
+#    - "https://github.com/SonarSource/sonar-ldap/releases/download/2.2-RC3/sonar-ldap-plugin-2.2.0.601.jar"
+plugins:
+  install:
+      - "https://sonarsource.bintray.com/Distribution/sonar-auth-github-plugin/sonar-auth-github-plugin-1.3.jar"
+  resources: {}
+  # We allow the plugins init container to have a separate resources declaration because
+  # the initContainer does not take as much resources.
+
+# A custom sonar.properties file can be provided using a multiline YAML string.
+sonarProperties: |
+  sonar.forceAuthentication=true
+  sonar.core.serverBaseURL=https://sonar.screwdriver.cd
+  sonar.auth.github.enabled=true
+  sonar.auth.github.clientId.secured=YOUR_CLIENT_ID
+  sonar.auth.github.clientSecret.secured=YOUR_CLIENT_SECRET
+  sonar.auth.github.organizations=screwdriver-cd
+
+## Configuration values for the postgresql dependency
+## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md
+##
+postgresql:
+  # Enable to deploy the PostgreSQL chart
+  enabled: true
+  # To use an external PostgreSQL instance, set enabled to false and uncomment
+  # the line below:
+  # postgresServer: ""
+  postgresUser: "YOUR_POSTGRES_USER"
+  postgresPassword: "YOUR_POSTGRES_PASSWORD"
+  postgresDatabase: "sonarDB"
+
+  # Specify the TCP port that PostgreSQL should use
+  service:
+    port: 5432

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,42 @@
+shared:
+    image: node:8
+
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        steps:
+            - echo: doing nothing here
+
+    # Deploy to beta environment and run tests
+    beta:
+        requires: [main]
+        steps:
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
+            - deploy-k8s: ./ci/k8s-deploy.sh
+            - test: sleep 120 && curl --silent --fail -o /dev/null https://beta-sonar.screwdriver.cd
+        environment:
+            K8S_TAG: 6.7.3
+            K8S_CONTAINER: sonarqube
+            K8S_IMAGE: sonarqube
+            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_DEPLOYMENT: beta-sonarqube
+        secrets:
+            # Talking to Kubernetes
+            - K8S_TOKEN
+
+    # Deploy to prod environment and run tests
+    prod:
+        requires: [beta]
+        steps:
+            - setup-ci: git clone https://github.com/screwdriver-cd/toolbox.git ci
+            - deploy-k8s: ./ci/k8s-deploy.sh
+            - test: sleep 120 && curl --silent --fail -o /dev/null https://sonar.screwdriver.cd
+        environment:
+            K8S_TAG: 6.7.3
+            K8S_CONTAINER: sonarqube
+            K8S_IMAGE: sonarqube
+            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_DEPLOYMENT: prod-sonarqube
+        secrets:
+            # Talking to Kubernetes
+            - K8S_TOKEN

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -5,7 +5,7 @@ jobs:
     main:
         requires: [~pr, ~commit]
         steps:
-            - echo: doing nothing here
+            - echo: echo doing nothing here
 
     # Deploy to beta environment and run tests
     beta:


### PR DESCRIPTION
This pipeline only has an example config and the a pipeline to update sonarqube image.
The actual config is stored internally.

Related to: https://github.com/screwdriver-cd/screwdriver/issues/1007