### PR TITLE
fix: switch k8s api endpoint

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -18,7 +18,7 @@ jobs:
             K8S_TAG: 6.7.3
             K8S_CONTAINER: sonarqube
             K8S_IMAGE: sonarqube
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: beta-sonarqube
         secrets:
             # Talking to Kubernetes
@@ -35,7 +35,7 @@ jobs:
             K8S_TAG: 6.7.3
             K8S_CONTAINER: sonarqube
             K8S_IMAGE: sonarqube
-            K8S_HOST: api.k8s.screwdriver.cd
+            K8S_HOST: api.ossd.k8s.screwdriver.cd
             K8S_DEPLOYMENT: prod-sonarqube
         secrets:
             # Talking to Kubernetes


### PR DESCRIPTION
## Context

Our K8S_DEPLOY step is currently failing.
Previously we point `api.k8s.screwdriver.cd`  to the ips for `api.ossd.k8s.screwdriver.cd` in AWS route53. That means whenever we update the cluster, manual change is needed. Switch to the correct endpoint.

## Objective

This PR updates to the correct host.

## References

Related to https://github.com/screwdriver-cd/guide/pull/256