### PR TITLE
fix: Update plugin download link

### DIFF
--- a/config-example/values.yaml
+++ b/config-example/values.yaml
@@ -46,6 +46,7 @@ readinessProbe:
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 30
+  timeoutSeconds: 10
 
 # Set extra env variables. Like proxy settings.
 extraEnv: {}

--- a/config-example/values.yaml
+++ b/config-example/values.yaml
@@ -82,7 +82,7 @@ persistence:
 #    - "https://github.com/SonarSource/sonar-ldap/releases/download/2.2-RC3/sonar-ldap-plugin-2.2.0.601.jar"
 plugins:
   install:
-      - "https://sonarsource.bintray.com/Distribution/sonar-auth-github-plugin/sonar-auth-github-plugin-1.3.jar"
+      - "https://binaries.sonarsource.com/Distribution/sonar-auth-github-plugin/sonar-auth-github-plugin-1.3.jar"
   resources: {}
   # We allow the plugins init container to have a separate resources declaration because
   # the initContainer does not take as much resources.


### PR DESCRIPTION
## Context

The github plugin link is outdated and no longer available.

## Objective

This PR updates the link to the correct one.

## References

Link to plugin documentation: https://docs.sonarqube.org/display/PLUG/GitHub+Authentication+Plugin

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
