### PR TITLE
fix: Update sonarProperties variable as dict

### DIFF
--- a/config-example/values.yaml
+++ b/config-example/values.yaml
@@ -88,14 +88,14 @@ plugins:
   # We allow the plugins init container to have a separate resources declaration because
   # the initContainer does not take as much resources.
 
-# A custom sonar.properties file can be provided using a multiline YAML string.
-sonarProperties: |
-  sonar.forceAuthentication=true
-  sonar.core.serverBaseURL=https://sonar.screwdriver.cd
-  sonar.auth.github.enabled=true
-  sonar.auth.github.clientId.secured=YOUR_CLIENT_ID
-  sonar.auth.github.clientSecret.secured=YOUR_CLIENT_SECRET
-  sonar.auth.github.organizations=screwdriver-cd
+# A custom sonar.properties file can be provided via dictionary.
+sonarProperties:
+  sonar.forceAuthentication: true
+  sonar.core.serverBaseURL: https://sonar.screwdriver.cd
+  sonar.auth.github.enabled: true
+  sonar.auth.github.clientId.secured: YOUR_CLIENT_ID
+  sonar.auth.github.clientSecret.secured: YOUR_CLIENT_SECRET
+  sonar.auth.github.organizations: screwdriver-cd
 
 ## Configuration values for the postgresql dependency
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md


### PR DESCRIPTION
## Context

Sonarqube for Helm is on version 2.1.4 now. This version has `sonarProperties` as a dict.

## Objective

This PR updates sonarProperties to match the stable helm chart.

## References

Related to https://github.com/helm/charts/pull/14223/files

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
